### PR TITLE
Update async & performance/ch3.md (fix error type)

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -593,7 +593,7 @@ p.then(
 		// never gets here :(
 	},
 	function rejected(err){
-		// `err` will be a `TypeError` exception object
+		// `err` will be a `ReferenceError` exception object
 		// from the `foo.bar()` line.
 	}
 );
@@ -621,7 +621,7 @@ p.then(
 );
 ```
 
-Wait, that makes it seem like the exception from `foo.bar()` really did get swallowed. Never fear, it didn't. But something deeper is wrong, which is that we've failed to listen for it. The `p.then(..)` call itself returns another promise, and it's *that* promise that will be rejected with the `TypeError` exception.
+Wait, that makes it seem like the exception from `foo.bar()` really did get swallowed. Never fear, it didn't. But something deeper is wrong, which is that we've failed to listen for it. The `p.then(..)` call itself returns another promise, and it's *that* promise that will be rejected with the `ReferenceError` exception.
 
 Why couldn't it just call the error handler we have defined there? Seems like a logical behavior on the surface. But it would violate the fundamental principle that Promises are **immutable** once resolved. `p` was already fulfilled to the value `42`, so it can't later be changed to a rejection just because there's an error in observing `p`'s resolution.
 


### PR DESCRIPTION
I think that the error type mentioned in text should be changed from TypeError to ReferenceError (or maybe some 'foo' variable should be defined in global or function scope to get actually TypeError).
